### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.UTF_8
+++ b/README.UTF_8
@@ -2200,7 +2200,7 @@ Child tags:
     to tune some other features as well.
 
     Currently the library-options allow additional extraction of the so called
-    auxilary data (explained below) and provide control over the video
+    auxiliary data (explained below) and provide control over the video
     thumbnail generation.
 
     Here is some information on the auxdata: UPnP defines certain tags to pass


### PR DESCRIPTION
cmd-ntrf, I've corrected a typographical error in the documentation of the [mediatomb](https://github.com/cmd-ntrf/mediatomb) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
